### PR TITLE
Ability to read and log parameters before execution

### DIFF
--- a/src/Tests.Dapper.Oracle/OracleDynamicParameterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleDynamicParameterTests.cs
@@ -152,5 +152,13 @@ namespace Tests.Dapper.Oracle
             param.Value.Should().Be("Bar");
             param.ArrayBindSize.Should().BeSameAs(bindSizeArray);
         }
+
+        [Fact]
+        public void GetParameterValue()
+        {
+            testObject.Add("Foo", "Bar", OracleMappingType.Varchar2);
+
+            testObject.Get<string>("Foo").Should().Be("Bar");
+        }
     }
 }


### PR DESCRIPTION
I modified method Get<T> to be able to read parameters before execution. 
Having logged DB procedure name and parameter value is extremely important for debugging.
Very often we have on production that DB procedure did not returned any value or exception and we need parameter value as an input to reproduce the issue.