### PR TITLE
Refactored the OracleValueConverter to support Get<int> and Get<long>.

### DIFF
--- a/src/Dapper.Oracle/Dapper.Oracle.StrongName.csproj
+++ b/src/Dapper.Oracle/Dapper.Oracle.StrongName.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.targets" />
   <PropertyGroup>
     <IsTestProject>false</IsTestProject>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(IsNetFramework) ">
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.2" />
+        <PackageReference Include="Dapper" Version="2.0.35" />
   </ItemGroup>
   <PropertyGroup Condition=" $(IsNetFramework) ">
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/src/Dapper.Oracle/Dapper.Oracle.csproj
+++ b/src/Dapper.Oracle/Dapper.Oracle.csproj
@@ -3,7 +3,7 @@
     <Import Project="..\common.targets" />
     <PropertyGroup>
         <IsTestProject>false</IsTestProject>
-        <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup Condition=" $(IsNetFramework) ">
@@ -15,9 +15,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="1.50.2" />
+        <PackageReference Include="Dapper" Version="2.0.35" />
     </ItemGroup>
     <PropertyGroup Condition=" $(IsNetFramework) ">
-        <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+        <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     </PropertyGroup>
 </Project>

--- a/src/Dapper.Oracle/OracleDynamicParameters.cs
+++ b/src/Dapper.Oracle/OracleDynamicParameters.cs
@@ -157,7 +157,7 @@ namespace Dapper.Oracle
         /// <returns>The value, note DBNull.Value is not returned, instead the value is returned as null</returns>
         public T Get<T>(string name)
         {
-            var paramInfo = Parameters[Clean(name)];
+            var paramInfo = GetParameter(name);
             var attachedParam = paramInfo.AttachedParam;
             object val = attachedParam == null ? paramInfo.Value : attachedParam.Value;
             if (val == DBNull.Value)
@@ -174,7 +174,7 @@ namespace Dapper.Oracle
 
         public OracleParameterInfo GetParameter(string name)
         {
-            return OracleMethodHelper.GetParameterInfo(Parameters[Clean(name)].AttachedParam);
+            return Parameters[Clean(name)];
         }
 
         void SqlMapper.IDynamicParameters.AddParameters(IDbCommand command, SqlMapper.Identity identity)

--- a/src/Tests.Dapper.Oracle/OracleDynamicParameterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleDynamicParameterTests.cs
@@ -160,5 +160,18 @@ namespace Tests.Dapper.Oracle
 
             testObject.Get<string>("Foo").Should().Be("Bar");
         }
+
+        [Fact]
+        public void GetParameter()
+        {
+            testObject.Add("Foo", "Bar", OracleMappingType.Varchar2);
+
+            var param = testObject.GetParameter("Foo");
+
+            param.Should().NotBeNull();
+            param.Name.Should().Be("Foo");
+            param.Value.Should().Be("Bar");
+            param.DbType.Should().Be(OracleMappingType.Varchar2);
+        }
     }
 }

--- a/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
@@ -47,15 +47,150 @@ namespace Tests.Dapper.Oracle
         [Fact]
         public void GetNullAsDecimalReturns0()
         {
-            var result = OracleValueConverter.Convert<double>(null);
+            var result = OracleValueConverter.Convert<decimal>(null);
             result.Should().Be(0);
         }
 
         [Fact]
+        public void GetDbNullAsDecimalReturns0()
+        {
+            var result = OracleValueConverter.Convert<decimal>(DBNull.Value);
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public void GetNullAsInt32Returns0()
+        {
+            var result = OracleValueConverter.Convert<int>(null);
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public void GetDbNullAsInt32Returns0()
+        {
+            var result = OracleValueConverter.Convert<int>(DBNull.Value);
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public void GetNullAsInt64Returns0()
+        {
+            var result = OracleValueConverter.Convert<long>(null);
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public void GetDbNullAsInt64Returns0()
+        {
+            var result = OracleValueConverter.Convert<long>(DBNull.Value);
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public void GetNullAsNullableDecimalReturnsNull()
+        {
+            var result = OracleValueConverter.Convert<decimal?>(null);
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetNullAsNullableInt32ReturnsNull()
+        {
+            var result = OracleValueConverter.Convert<int?>(null);
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetNullAsNullableInt64ReturnsNull()
+        {
+            var result = OracleValueConverter.Convert<long?>(null);
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public void GetDbNullAsDecimalReturnsNull()
+        {
+            var result = OracleValueConverter.Convert<decimal?>(DBNull.Value);
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public void GetDbNullAsInt32ReturnsNull()
+        {
+            var result = OracleValueConverter.Convert<int?>(DBNull.Value);
+            result.Should().Be(null);
+        }
+
+        [Fact]
+        public void GetDbNullAsInt64ReturnsNull()
+        {
+            var result = OracleValueConverter.Convert<long?>(DBNull.Value);
+            result.Should().Be(null);
+        }
+
+
+        [Fact]
         public void GetOracleDecimalReturnsDecimal()
         {
-            var result = OracleValueConverter.Convert<decimal>(new OracleDecimal(100));
-            result.Should().Be(100);
+            decimal expected = 100;
+
+            var result = OracleValueConverter.Convert<decimal>(new OracleDecimal(expected));
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetOracleDecimalReturnsNullableDecimal()
+        {
+            decimal expected = 100;
+
+            var result = OracleValueConverter.Convert<decimal?>(new OracleDecimal(expected));
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetOracleDecimalReturnsInt32()
+        {
+            decimal input = 100;
+            var expected = Convert.ToInt32(input);
+
+            var result = OracleValueConverter.Convert<int>(new OracleDecimal(input));
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetOracleDecimalReturnsNullableInt32()
+        {
+            decimal input = 100;
+            var expected = Convert.ToInt32(input);
+
+            var result = OracleValueConverter.Convert<int?>(new OracleDecimal(input));
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetOracleDecimalReturnsInt64()
+        {
+            decimal input = 100;
+            var expected = Convert.ToInt64(input);
+
+            var result = OracleValueConverter.Convert<long>(new OracleDecimal(input));
+
+            result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetOracleDecimalReturnsNullableInt64()
+        {
+            decimal input = 100;
+            var expected = Convert.ToInt64(input);
+
+            var result = OracleValueConverter.Convert<long?>(new OracleDecimal(input));
+
+            result.Should().Be(expected);
         }
 
         [Fact]
@@ -64,15 +199,5 @@ namespace Tests.Dapper.Oracle
             var result = OracleValueConverter.Convert<DateTime>(new OracleDate(DateTime.Today));
             result.Should().Be(DateTime.Today);
         }
-
-        [Fact]
-        public void GetOracleNumberReturnAsDecimal()
-        {
-            decimal expected = 100;
-            var result = OracleValueConverter.Convert<decimal>(100);
-            result.Should().Be(expected);
-        }
-    }
-
-    
+    }  
 }

--- a/src/Tests.Dapper.Oracle/Tests.Dapper.Oracle.csproj
+++ b/src/Tests.Dapper.Oracle/Tests.Dapper.Oracle.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.3.0" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.18.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
- Fixes DIPSAS/Dapper.Oracle#40
- Fixes DIPSAS/Dapper.Oracle#42
- Refactored the OracleValueConverter to handle OracleParameter values and allow Oracle native NUMBER values to convert to Int32 and Int64.
- Refactored the OracleValueConverter.GetParameter() method to return OracleParameterInfo instead of the AttachedParam.
- Removed .NET 4.5.1 framework support (EOL).
- Updated Dapper version to 2.0.35.