### PR TITLE
Fixing converting Boolean, TimeStamp, Date and Byte to .NET native data types

### DIFF
--- a/src/Dapper.Oracle/OracleValueConverter.cs
+++ b/src/Dapper.Oracle/OracleValueConverter.cs
@@ -77,13 +77,15 @@ namespace Dapper.Oracle
                 for (int i = 0; i < arr.Length; i++)
                 {
                     var oraDate = arr.GetValue(i);
-                    if (oraDate == null)
+                    dateArray[i] = null;
+
+                    if (oraDate != null)
                     {
-                        dateArray[i] = null;
-                    }
-                    else
-                    {
-                        dateArray[i] = (DateTime?)oraDate?.GetType()?.GetProperty("Value")?.GetValue(oraDate, null);
+                        var isOraDateValNull = (bool)oraDate?.GetType()?.GetProperty("IsNull")?.GetValue(oraDate, null);
+                        if(!isOraDateValNull)
+                        {
+                            dateArray[i] = (DateTime?)oraDate?.GetType()?.GetProperty("Value")?.GetValue(oraDate, null);
+                        }
                     }
                 }
                 return (T)System.Convert.ChangeType(dateArray, nullableType ?? typeof(T));

--- a/src/Dapper.Oracle/OracleValueConverter.cs
+++ b/src/Dapper.Oracle/OracleValueConverter.cs
@@ -99,7 +99,7 @@ namespace Dapper.Oracle
                     var shortArray = new short[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        shortArray[i] = short.Parse(arr.GetValue(i).ToString());
+                        shortArray[i] = short.Parse(arr.GetValue(i)?.ToString());
                     }
                     return (T)System.Convert.ChangeType(shortArray, nullableType ?? typeof(T));
 
@@ -107,7 +107,7 @@ namespace Dapper.Oracle
                     var intArray = new int[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        intArray[i] = int.Parse(arr.GetValue(i).ToString());
+                        intArray[i] = int.Parse(arr.GetValue(i)?.ToString());
                     }
                     return (T)System.Convert.ChangeType(intArray, nullableType ?? typeof(T));
 
@@ -115,7 +115,7 @@ namespace Dapper.Oracle
                     var longArray = new long[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        longArray[i] = long.Parse(arr.GetValue(i).ToString());
+                        longArray[i] = long.Parse(arr.GetValue(i)?.ToString());
                     }
                     return (T)System.Convert.ChangeType(longArray, nullableType ?? typeof(T));
 
@@ -124,21 +124,21 @@ namespace Dapper.Oracle
                     var decimalArray = new decimal[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        decimalArray[i] = decimal.Parse(arr.GetValue(i).ToString());
+                        decimalArray[i] = decimal.Parse(arr.GetValue(i)?.ToString());
                     }
                     return (T)System.Convert.ChangeType(decimalArray, nullableType ?? typeof(T));
                 case "System.Boolean[]":
                     var boolArray = new bool[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        boolArray[i] = bool.Parse(arr.GetValue(i).ToString());
+                        boolArray[i] = bool.Parse(arr.GetValue(i)?.ToString());
                     }
                     return (T)System.Convert.ChangeType(boolArray, nullableType ?? typeof(T));
                 default:
                     var strArray = new string[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        strArray[i] = arr.GetValue(i).ToString();
+                        strArray[i] = arr.GetValue(i)?.ToString();
                     }
                     return (T)System.Convert.ChangeType(strArray, nullableType ?? typeof(T));
             }

--- a/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
@@ -80,11 +80,11 @@ namespace Tests.Dapper.Oracle
             };
             var result = OracleValueConverter.Convert<DateTime[]>(oraDateArray);
             result.Should().BeOfType<DateTime[]>();
-            result.Should().HaveCount(3);
+            result.Should().HaveCount(oraDateArray.Length);
 
             var secondResult = OracleValueConverter.Convert<DateTime?[]>(nullableOraDateArray);
             secondResult.Should().BeOfType<DateTime?[]>();
-            secondResult.Should().HaveCount(4);
+            secondResult.Should().HaveCount(nullableOraDateArray.Length);
         }
 
         [Fact]

--- a/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
@@ -2,6 +2,7 @@
 using System.Text;
 using Dapper.Oracle;
 using FluentAssertions;
+using Oracle.ManagedDataAccess.Client;
 #if NETCOREAPP2_0
 using Oracle.ManagedDataAccess.Types;
 #else
@@ -14,6 +15,78 @@ namespace Tests.Dapper.Oracle
 {
     public class OracleValueConverterTests
     {
+        [Fact]
+        public void GetOracleBoolean()
+        {
+            var oraBool = new OracleBoolean(true);
+            var result = OracleValueConverter.Convert<bool>(oraBool);
+            result.Should().Be(true);
+
+            oraBool = new OracleBoolean(-1);
+            result = OracleValueConverter.Convert<bool>(oraBool);
+            result.Should().Be(true);
+
+            oraBool = new OracleBoolean(1);
+            result = OracleValueConverter.Convert<bool>(oraBool);
+            result.Should().Be(true);
+
+            oraBool = new OracleBoolean(0);
+            result = OracleValueConverter.Convert<bool>(oraBool);
+            result.Should().Be(false);
+
+            var oraBoolArr = new OracleBoolean[2] { true, false };
+            var resultArr = OracleValueConverter.Convert<bool[]>(oraBoolArr);
+            resultArr.Should().BeOfType<bool[]>();
+            resultArr.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void GetOracleBinary()
+        {
+            var bytes = Encoding.UTF8.GetBytes("Lorem ipsum");
+            var oracleBytes = new OracleBinary(bytes);
+            var result = OracleValueConverter.Convert<byte[]>(oracleBytes);
+            result.Should().Equal(bytes);
+        }
+
+        [Fact]
+        public void GetOracleTimeStamp()
+        {
+            var dateNow = DateTime.Now;
+            var oraTimeStamp = new OracleTimeStamp(dateNow);
+            var result = OracleValueConverter.Convert<DateTime>(oraTimeStamp);
+            result.Should().Be(dateNow);
+
+            var oraTimeStampArr = new OracleTimeStamp[1] { dateNow };
+            var secondResult = OracleValueConverter.Convert<DateTime[]>(oraTimeStampArr);
+            secondResult.Should().BeOfType<DateTime[]>();
+            secondResult.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void GetOracleDateArray()
+        {
+            var oraDateArray = new OracleDate[] { 
+                (OracleDate)DateTime.Now,
+                (OracleDate)DateTime.Now.AddYears(1),
+                new OracleDate("10/29/2020 16:14:23")
+            };
+
+            var nullableOraDateArray = new OracleDate?[] {
+                (OracleDate)DateTime.Now,
+                (OracleDate)DateTime.Now.AddYears(1),
+                null,
+                new OracleDate("10/29/2020 16:14:23")
+            };
+            var result = OracleValueConverter.Convert<DateTime[]>(oraDateArray);
+            result.Should().BeOfType<DateTime[]>();
+            result.Should().HaveCount(3);
+
+            var secondResult = OracleValueConverter.Convert<DateTime?[]>(nullableOraDateArray);
+            secondResult.Should().BeOfType<DateTime?[]>();
+            secondResult.Should().HaveCount(4);
+        }
+
         [Fact]
         public void GetStringArray()
         {

--- a/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
@@ -94,6 +94,11 @@ namespace Tests.Dapper.Oracle
             var result = OracleValueConverter.Convert<string[]>(oraArray);
             result.Should().BeOfType<string[]>();
             result.Should().HaveCount(2);
+
+            oraArray = new[] { "Foo", "Bar", null };
+            result = OracleValueConverter.Convert<string[]>(oraArray);
+            result.Should().BeOfType<string[]>();
+            result.Should().HaveCount(3);
         }
 
         [Fact]


### PR DESCRIPTION
Just as the title says - Fixing converting OracleBoolean, OracleTimeStamp, OracleDate and OracleBinary to .NET native data types.
Working with Dapper.Oracle i realized that we are missing conversion from Oracle types to .NET native