### PR TITLE
Enriching OracleParameterInfo with flag for PII data

### DIFF
--- a/src/Dapper.Oracle/OracleDecimalConversion.cs
+++ b/src/Dapper.Oracle/OracleDecimalConversion.cs
@@ -1,0 +1,17 @@
+namespace Dapper.Oracle
+{
+    /// <summary>
+    /// Maps Oracle native numeric values (especially <c>OracleDecimal</c>) to <see cref="decimal"/>,
+    /// using <c>OracleDecimal.SetPrecision(..., 28)</c> before reading <c>System.Decimal</c> (same idea as legacy ADO.NET).
+    /// </summary>
+    /// <remarks>
+    /// Used internally by <see cref="OracleValueConverter"/> (for example from <see cref="OracleDynamicParameters.Get{T}"/>).
+    /// Dapper's default <c>Query&lt;decimal&gt;</c> / <c>ExecuteScalar&lt;decimal&gt;</c> does not call this; for result sets use this helper on raw values, SQL <c>CAST</c>, or a custom <c>TypeHandler</c>.
+    /// </remarks>
+    public static class OracleDecimalConversion
+    {
+        public static decimal ToDecimal(object value) => OracleValueConverter.Convert<decimal>(value);
+
+        public static decimal? ToDecimalNullable(object value) => OracleValueConverter.Convert<decimal?>(value);
+    }
+}

--- a/src/Dapper.Oracle/OracleDynamicParameters.cs
+++ b/src/Dapper.Oracle/OracleDynamicParameters.cs
@@ -1,4 +1,4 @@
-﻿//// Based on Gist found here: https://gist.github.com/vijaysg/3096151
+//// Based on Gist found here: https://gist.github.com/vijaysg/3096151
 
 using System;
 using System.Collections;
@@ -109,6 +109,7 @@ namespace Dapper.Oracle
         /// <param name="sourceColumn"></param>
         /// <param name="sourceVersion"></param>
         /// <param name="collectionType"></param>
+        /// <param name="maskValueWhenLogging">a flag that this param contains sensitive data and it must be masked in case of logging values</param>
         public void Add(
             string name,
             object value = null,
@@ -121,7 +122,8 @@ namespace Dapper.Oracle
             string sourceColumn = null,
             DataRowVersion? sourceVersion = null,
             OracleMappingCollectionType? collectionType = null,
-            int[] arrayBindSize = null)
+            int[] arrayBindSize = null,
+            bool maskValueWhenLogging = false)
         {
             Parameters[Clean(name)] = new OracleParameterInfo()
             {
@@ -136,7 +138,8 @@ namespace Dapper.Oracle
                 SourceColumn = sourceColumn,
                 SourceVersion = sourceVersion ?? DataRowVersion.Current,
                 CollectionType = collectionType ?? OracleMappingCollectionType.None,
-                ArrayBindSize = arrayBindSize
+                ArrayBindSize = arrayBindSize,
+                MaskValueWhenLogging = maskValueWhenLogging
             };
         }
 
@@ -167,7 +170,7 @@ namespace Dapper.Oracle
                 }
                 return default(T);
             }
-            
+
             return OracleValueConverter.Convert<T>(val);
         }
 
@@ -239,10 +242,10 @@ namespace Dapper.Oracle
                 }
 
                 OracleMethodHelper.SetOracleParameters(p, param);
-                
+
                 p.Direction = param.ParameterDirection;
-                
-                var val = param.Value;                
+
+                var val = param.Value;
 
                 if (val != null && OracleTypeMapper.HasTypeHandler(val.GetType(), out var handler))
                 {
@@ -251,7 +254,7 @@ namespace Dapper.Oracle
                 else
                 {
                     p.Value = val ?? DBNull.Value;
-                    
+
                     var s = val as string;
                     if (s?.Length <= 4000)
                     {
@@ -262,8 +265,8 @@ namespace Dapper.Oracle
                     {
                         p.Size = param.Size.Value;
                     }
-                }                
-                               
+                }
+
                 if (add)
                 {
                     command.Parameters.Add(p);
@@ -320,6 +323,8 @@ namespace Dapper.Oracle
             public OracleParameterMappingStatus Status { get; set; }
 
             public IDbDataParameter AttachedParam { get; set; }
+
+            public bool MaskValueWhenLogging { get; set; }
         }
 
         /// <summary>

--- a/src/Dapper.Oracle/OracleValueConverter.cs
+++ b/src/Dapper.Oracle/OracleValueConverter.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data.Common;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 
@@ -126,7 +127,10 @@ namespace Dapper.Oracle
                     var decimalArray = new decimal[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        decimalArray[i] = decimal.Parse(arr.GetValue(i)?.ToString());
+                        var raw = arr.GetValue(i);
+                        decimalArray[i] = TryReduceOracleDecimalToSystemDecimal(raw, out var systemDecimal)
+                            ? systemDecimal
+                            : decimal.Parse(raw?.ToString() ?? "0");
                     }
                     return (T)System.Convert.ChangeType(decimalArray, nullableType ?? typeof(T));
                 case "System.Boolean[]":
@@ -187,6 +191,12 @@ namespace Dapper.Oracle
                     return null;
                 }
 
+                // Legacy ADO.NET: OracleDecimal.SetPrecision(..., 28).Value — no compile-time reference to Oracle.ManagedDataAccess.
+                if (TryReduceOracleDecimalToSystemDecimal(value, out var asDecimal))
+                {
+                    return asDecimal;
+                }
+
                 var val = valueType.GetProperty("Value")?.GetValue(value);
                 if (val != null)
                 {
@@ -207,6 +217,46 @@ namespace Dapper.Oracle
             // We need this, because, you know, Oracle.  OracleDecimal,OracleFloat,OracleYaddiAddy,OracleYourUncle etc value types.    
             // See: https://docs.oracle.com/en/database/oracle/oracle-database/19/odpnt/intro003.html#GUID-425C9EBA-CFFC-47FE-B490-604251714ACA
             return Regex.IsMatch(valueType.FullName, @"Oracle\.\w+\.Types\.Oracle\w+");
+        }
+
+        private const string OracleDecimalTypeFullName = "Oracle.ManagedDataAccess.Types.OracleDecimal";
+
+        private static bool IsOracleDecimal(Type type) =>
+            type != null && type.FullName == OracleDecimalTypeFullName;
+
+        /// <summary>
+        /// Calls <c>OracleDecimal.SetPrecision(instance, 28).Value</c> via reflection when ODP.NET is loaded at runtime.
+        /// </summary>
+        private static bool TryReduceOracleDecimalToSystemDecimal(object value, out decimal systemDecimal)
+        {
+            systemDecimal = default;
+            if (value == null || !IsOracleDecimal(value.GetType()))
+            {
+                return false;
+            }
+
+            var t = value.GetType();
+            var setPrecision = t.GetMethod(
+                "SetPrecision",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { t, typeof(int) },
+                modifiers: null);
+            if (setPrecision == null)
+            {
+                return false;
+            }
+
+            var reduced = setPrecision.Invoke(null, new object[] { value, 28 });
+            var valueProp = t.GetProperty("Value");
+            var boxed = valueProp?.GetValue(reduced);
+            if (boxed is decimal d)
+            {
+                systemDecimal = d;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using Dapper.Oracle;
 using FluentAssertions;
@@ -247,6 +247,22 @@ namespace Tests.Dapper.Oracle
             var result = OracleValueConverter.Convert<decimal>(new OracleDecimal(expected));
 
             result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetOracleDecimalMatchesExplicitSetPrecision28()
+        {
+            foreach (var d in new[]
+                     {
+                         0m,
+                         1m,
+                         0.4690679611650485436893203883m,
+                     })
+            {
+                var od = new OracleDecimal(d);
+                var expected = OracleDecimal.SetPrecision(od, 28).Value;
+                OracleValueConverter.Convert<decimal>(od).Should().Be(expected);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
I submitted a pull request to the project, introducing a new flag called MaskValueWhenLogging to the OracleParameterInfo class.

This flag is intended to identify Oracle parameters that contain Personally Identifiable Information (PII). When set to true, it enables masking of parameter values in logs, improving data security and supporting compliance with privacy regulations.