### PR TITLE
Enriching OracleParameterInfo with flag for PII data and Fix OracleDecimal to System.Decimal conversion overflow handling

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -11,4 +11,4 @@ if ($connectionstring)
 dotnet restore .\src\Dapper.Oracle.sln
 dotnet build .\src\Dapper.Oracle.sln
 dotnet test .\src\Dapper.Oracle.sln
-dotnet pack .\src\Dapper.Oracle.sln -p:PackageVersion=2.0.4
+dotnet pack .\src\Dapper.Oracle.sln -p:PackageVersion=2.1.0

--- a/src/Dapper.Oracle.StrongName/Dapper.Oracle.StrongName.csproj
+++ b/src/Dapper.Oracle.StrongName/Dapper.Oracle.StrongName.csproj
@@ -13,10 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper.StrongName" Version="2.0.123" />
+        <PackageReference Include="Dapper.StrongName" Version="2.1.72" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     </ItemGroup>
 </Project>

--- a/src/Dapper.Oracle.StrongName/Dapper.Oracle.StrongName.csproj
+++ b/src/Dapper.Oracle.StrongName/Dapper.Oracle.StrongName.csproj
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\common.targets" />
     <PropertyGroup>
         <IsTestProject>false</IsTestProject>
-        <TargetFrameworks>net7.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>

--- a/src/Dapper.Oracle/Dapper.Oracle.csproj
+++ b/src/Dapper.Oracle/Dapper.Oracle.csproj
@@ -1,23 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <Import Project="..\common.targets" />
     <PropertyGroup>
         <IsTestProject>false</IsTestProject>
-        <TargetFrameworks>net7.0</TargetFrameworks>
+        <TargetFrameworks>net10.0</TargetFrameworks>
     </PropertyGroup>
 
 	<PropertyGroup>
 		<PackageReleaseNotes>
-Version 2.0.4:
- - Updated to use .net 7.0.
- - Dependency switched to most recent version of Dapper: 2.0.123.
- - Dependencies updated also for test project.
-		</PackageReleaseNotes>
+      Version 2.1.0:
+      - Updated to use .net 10.0.
+      - Dependency switched to most recent version of Dapper: 2.1.66.
+      - Dependencies updated also for test project.
+      - Fix OracleDecimal to System.Decimal conversion overflow handling
+      - Enriching OracleParameterInfo with flag for PII data
+    </PackageReleaseNotes>
 		<!--<PackageReadmeFile>..\..\README.MD</PackageReadmeFile>-->
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="Dapper" Version="2.0.123" />
+        <PackageReference Include="Dapper" Version="2.1.66" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Dapper.Oracle/Dapper.Oracle.csproj
+++ b/src/Dapper.Oracle/Dapper.Oracle.csproj
@@ -10,7 +10,7 @@
 		<PackageReleaseNotes>
       Version 2.1.0:
       - Updated to use .net 10.0.
-      - Dependency switched to most recent version of Dapper: 2.1.66.
+      - Dependency switched to most recent version of Dapper: 2.1.72.
       - Dependencies updated also for test project.
       - Fix OracleDecimal to System.Decimal conversion overflow handling
       - Enriching OracleParameterInfo with flag for PII data
@@ -19,10 +19,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.66" />
+        <PackageReference Include="Dapper" Version="2.1.72" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+      <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     </ItemGroup>
 </Project>

--- a/src/Dapper.Oracle/OracleDecimalConversion.cs
+++ b/src/Dapper.Oracle/OracleDecimalConversion.cs
@@ -1,0 +1,17 @@
+namespace Dapper.Oracle
+{
+    /// <summary>
+    /// Maps Oracle native numeric values (especially <c>OracleDecimal</c>) to <see cref="decimal"/>,
+    /// using <c>OracleDecimal.SetPrecision(..., 28)</c> before reading <c>System.Decimal</c> (same idea as legacy ADO.NET).
+    /// </summary>
+    /// <remarks>
+    /// Used internally by <see cref="OracleValueConverter"/> (for example from <see cref="OracleDynamicParameters.Get{T}"/>).
+    /// Dapper's default <c>Query&lt;decimal&gt;</c> / <c>ExecuteScalar&lt;decimal&gt;</c> does not call this; for result sets use this helper on raw values, SQL <c>CAST</c>, or a custom <c>TypeHandler</c>.
+    /// </remarks>
+    public static class OracleDecimalConversion
+    {
+        public static decimal ToDecimal(object value) => OracleValueConverter.Convert<decimal>(value);
+
+        public static decimal? ToDecimalNullable(object value) => OracleValueConverter.Convert<decimal?>(value);
+    }
+}

--- a/src/Dapper.Oracle/OracleDynamicParameters.cs
+++ b/src/Dapper.Oracle/OracleDynamicParameters.cs
@@ -1,4 +1,4 @@
-﻿//// Based on Gist found here: https://gist.github.com/vijaysg/3096151
+//// Based on Gist found here: https://gist.github.com/vijaysg/3096151
 
 using System;
 using System.Collections;
@@ -109,6 +109,7 @@ namespace Dapper.Oracle
         /// <param name="sourceColumn"></param>
         /// <param name="sourceVersion"></param>
         /// <param name="collectionType"></param>
+        /// <param name="maskValueWhenLogging">a flag that this param contains sensitive data and it must be masked in case of logging values</param>
         public void Add(
             string name,
             object value = null,
@@ -121,7 +122,8 @@ namespace Dapper.Oracle
             string sourceColumn = null,
             DataRowVersion? sourceVersion = null,
             OracleMappingCollectionType? collectionType = null,
-            int[] arrayBindSize = null)
+            int[] arrayBindSize = null,
+            bool maskValueWhenLogging = false)
         {
             Parameters[Clean(name)] = new OracleParameterInfo()
             {
@@ -136,7 +138,8 @@ namespace Dapper.Oracle
                 SourceColumn = sourceColumn,
                 SourceVersion = sourceVersion ?? DataRowVersion.Current,
                 CollectionType = collectionType ?? OracleMappingCollectionType.None,
-                ArrayBindSize = arrayBindSize
+                ArrayBindSize = arrayBindSize,
+                MaskValueWhenLogging = maskValueWhenLogging
             };
         }
 
@@ -167,7 +170,7 @@ namespace Dapper.Oracle
                 }
                 return default(T);
             }
-            
+
             return OracleValueConverter.Convert<T>(val);
         }
 
@@ -239,10 +242,10 @@ namespace Dapper.Oracle
                 }
 
                 OracleMethodHelper.SetOracleParameters(p, param);
-                
+
                 p.Direction = param.ParameterDirection;
-                
-                var val = param.Value;                
+
+                var val = param.Value;
 
                 if (val != null && OracleTypeMapper.HasTypeHandler(val.GetType(), out var handler))
                 {
@@ -251,7 +254,7 @@ namespace Dapper.Oracle
                 else
                 {
                     p.Value = val ?? DBNull.Value;
-                    
+
                     var s = val as string;
                     if (s?.Length <= 4000)
                     {
@@ -262,8 +265,8 @@ namespace Dapper.Oracle
                     {
                         p.Size = param.Size.Value;
                     }
-                }                
-                               
+                }
+
                 if (add)
                 {
                     command.Parameters.Add(p);
@@ -320,6 +323,8 @@ namespace Dapper.Oracle
             public OracleParameterMappingStatus Status { get; set; }
 
             public IDbDataParameter AttachedParam { get; set; }
+
+            public bool MaskValueWhenLogging { get; set; }
         }
 
         /// <summary>

--- a/src/Dapper.Oracle/OracleValueConverter.cs
+++ b/src/Dapper.Oracle/OracleValueConverter.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data.Common;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using System.Text.RegularExpressions;
 
@@ -126,7 +127,10 @@ namespace Dapper.Oracle
                     var decimalArray = new decimal[arr.Length];
                     for (int i = 0; i < arr.Length; i++)
                     {
-                        decimalArray[i] = decimal.Parse(arr.GetValue(i)?.ToString());
+                        var raw = arr.GetValue(i);
+                        decimalArray[i] = TryReduceOracleDecimalToSystemDecimal(raw, out var systemDecimal)
+                            ? systemDecimal
+                            : decimal.Parse(raw?.ToString() ?? "0");
                     }
                     return (T)System.Convert.ChangeType(decimalArray, nullableType ?? typeof(T));
                 case "System.Boolean[]":
@@ -187,6 +191,12 @@ namespace Dapper.Oracle
                     return null;
                 }
 
+                // Legacy ADO.NET: OracleDecimal.SetPrecision(..., 28).Value — no compile-time reference to Oracle.ManagedDataAccess.
+                if (TryReduceOracleDecimalToSystemDecimal(value, out var asDecimal))
+                {
+                    return asDecimal;
+                }
+
                 var val = valueType.GetProperty("Value")?.GetValue(value);
                 if (val != null)
                 {
@@ -207,6 +217,46 @@ namespace Dapper.Oracle
             // We need this, because, you know, Oracle.  OracleDecimal,OracleFloat,OracleYaddiAddy,OracleYourUncle etc value types.    
             // See: https://docs.oracle.com/en/database/oracle/oracle-database/19/odpnt/intro003.html#GUID-425C9EBA-CFFC-47FE-B490-604251714ACA
             return Regex.IsMatch(valueType.FullName, @"Oracle\.\w+\.Types\.Oracle\w+");
+        }
+
+        private const string OracleDecimalTypeFullName = "Oracle.ManagedDataAccess.Types.OracleDecimal";
+
+        private static bool IsOracleDecimal(Type type) =>
+            type != null && type.FullName == OracleDecimalTypeFullName;
+
+        /// <summary>
+        /// Calls <c>OracleDecimal.SetPrecision(instance, 28).Value</c> via reflection when ODP.NET is loaded at runtime.
+        /// </summary>
+        private static bool TryReduceOracleDecimalToSystemDecimal(object value, out decimal systemDecimal)
+        {
+            systemDecimal = default;
+            if (value == null || !IsOracleDecimal(value.GetType()))
+            {
+                return false;
+            }
+
+            var t = value.GetType();
+            var setPrecision = t.GetMethod(
+                "SetPrecision",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { t, typeof(int) },
+                modifiers: null);
+            if (setPrecision == null)
+            {
+                return false;
+            }
+
+            var reduced = setPrecision.Invoke(null, new object[] { value, 28 });
+            var valueProp = t.GetProperty("Value");
+            var boxed = valueProp?.GetValue(reduced);
+            if (boxed is decimal d)
+            {
+                systemDecimal = d;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/src/Tests.Dapper.Oracle/IntegrationTests/DatabaseFixture.cs
+++ b/src/Tests.Dapper.Oracle/IntegrationTests/DatabaseFixture.cs
@@ -35,9 +35,8 @@ namespace Tests.Dapper.Oracle.IntegrationTests
 
         public async Task InitializeAsync()
         {
+            // Prefer DA_OR_CONNECTION (CI / local Oracle). Do not overwrite it — a hardcoded default used to break env-based runs.
             var connectionString = Environment.GetEnvironmentVariable("DA_OR_CONNECTION");
-
-            connectionString = "Data Source=localhost/dips;User Id=system;Password=oracle";
 
             if (string.IsNullOrEmpty(connectionString))
             {

--- a/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
+++ b/src/Tests.Dapper.Oracle/OracleValueConverterTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using Dapper.Oracle;
 using FluentAssertions;
@@ -247,6 +247,22 @@ namespace Tests.Dapper.Oracle
             var result = OracleValueConverter.Convert<decimal>(new OracleDecimal(expected));
 
             result.Should().Be(expected);
+        }
+
+        [Fact]
+        public void GetOracleDecimalMatchesExplicitSetPrecision28()
+        {
+            foreach (var d in new[]
+                     {
+                         0m,
+                         1m,
+                         0.4690679611650485436893203883m,
+                     })
+            {
+                var od = new OracleDecimal(d);
+                var expected = OracleDecimal.SetPrecision(od, 28).Value;
+                OracleValueConverter.Convert<decimal>(od).Should().Be(expected);
+            }
         }
 
         [Fact]

--- a/src/Tests.Dapper.Oracle/Tests.Dapper.Oracle.csproj
+++ b/src/Tests.Dapper.Oracle/Tests.Dapper.Oracle.csproj
@@ -5,18 +5,23 @@
     <IsTestProject>true</IsTestProject>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <!-- Integration tests need a live Oracle (see DatabaseFixture). Default: skip them; run all with: dotnet test -p:RunIntegrationTests=true -->
+    <RunIntegrationTests Condition="'$(RunIntegrationTests)' == ''">false</RunIntegrationTests>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(RunIntegrationTests)' != 'true'">
+    <VSTestTestCaseFilter>Category!=Integration&amp;Category!=IntegrationTest</VSTestTestCaseFilter>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.26.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.9.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.console" Version="2.9.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -36,7 +41,7 @@
     <EmbeddedResource Include="IntegrationTests\Schema.sql" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests.Dapper.Oracle/Tests.Dapper.Oracle.csproj
+++ b/src/Tests.Dapper.Oracle/Tests.Dapper.Oracle.csproj
@@ -1,22 +1,22 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\common.targets" />
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="3.21.100" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.26.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.console" Version="2.4.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### PII Data
I submitted a pull request to the project, introducing a new flag called MaskValueWhenLogging to the OracleParameterInfo class.

This flag is intended to identify Oracle parameters that contain Personally Identifiable Information (PII). When set to true, it enables masking of parameter values in logs, improving data security and supporting compliance with privacy regulations.

I find this flag very useful in practice. Here's a simple example demonstrating how it can be used to mask sensitive parameter values before logging:

`var paramDic = new Dictionary<string, string>();
foreach (var name in parameters?.ParameterNames)
{
    var paramInfo = parameters.GetParameter(name);

    string paramValue;

    if (paramInfo.MaskValueWhenLogging)
    {
        paramValue = "***MASKED***";
    }
    else
    {
        paramValue = GetParameterValue<dynamic>(parameters, name);
    }
	paramDic.Add(name, paramValue);
}
logger.LogInformation("SQL executed wiht {@parameters}", paramDic);`

This approach helps ensure that PII or other sensitive values are not exposed in logs while still retaining visibility into which parameters were used.

### Fix OracleDecimal to System.Decimal conversion overflow handling

Added explicit handling for Oracle NUMBER values that exceed the precision supported by System.Decimal.

Oracle NUMBER can store up to 38 digits of precision, while System.Decimal supports up to 28-29 digits. In some cases, ODP.NET throws an overflow exception during OracleDecimal to decimal conversion, causing Dapper mapping failures.

The fix applies precision normalization before converting OracleDecimal to System.Decimal to maintain compatibility with legacy ADO.NET behavior and prevent runtime overflow exceptions during result materialization.